### PR TITLE
Add a comment explaining why we are using passwordless sudo.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,8 @@
         name: wheel
         state: present
 
+    # We need passwordless sudo here since our admins are authenticating with
+    # ssh keys and do not have passwords associated with their accounts.
     - name: Allow wheel group to have passwordless sudo
       lineinfile:
         dest: /etc/sudoers


### PR DESCRIPTION
Be a bit more clear about why we are configuring sudo to allow escalation without a password. 

This closes #21.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

A concern was raised that we are endorsing the use of sudo without passwords.  This PR contains a comment
which adds additional context.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This PR clarifies why we are configuring sudo this way so it is not confused as a general endorsement as a best practice.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I read the comment, and thought it was good.

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->
![tenor-2](https://user-images.githubusercontent.com/3229435/108101415-2fb73900-7055-11eb-8395-b5dd0873b8ec.gif)

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] All new and existing tests pass.
